### PR TITLE
unable to process @Template without gwt-user in classpath

### DIFF
--- a/processor/src/main/java/org/gwtproject/safehtml/apt/SafeHtmlProcessor.java
+++ b/processor/src/main/java/org/gwtproject/safehtml/apt/SafeHtmlProcessor.java
@@ -55,9 +55,11 @@ public class SafeHtmlProcessor extends AbstractProcessor {
 
     templateTypes.addAll(roundEnv.getElementsAnnotatedWith(processingEnv.getElementUtils().getTypeElement(TEMPLATE_ANNOTATION_NAME))
             .stream().map(Element::getEnclosingElement).map(TypeElement.class::cast).collect(Collectors.toSet()));
-    templateTypes.addAll(roundEnv.getElementsAnnotatedWith(processingEnv.getElementUtils().getTypeElement(OLD_TEMPLATE_ANNOTATION_NAME))
-            .stream().map(Element::getEnclosingElement).map(TypeElement.class::cast).collect(Collectors.toSet()));
-
+    TypeElement oldTemplateAnnotationName = processingEnv.getElementUtils().getTypeElement(OLD_TEMPLATE_ANNOTATION_NAME);
+    if (oldTemplateAnnotationName != null) {
+      templateTypes.addAll(roundEnv.getElementsAnnotatedWith(oldTemplateAnnotationName)
+                                   .stream().map(Element::getEnclosingElement).map(TypeElement.class::cast).collect(Collectors.toSet()));
+    }
     for (TypeElement templateType : templateTypes) {
       try {
         String packageName = processingEnv.getElementUtils().getPackageOf(templateType).getQualifiedName().toString();


### PR DESCRIPTION
Caused by: java.lang.NullPointerException
    at com.sun.tools.javac.processing.JavacRoundEnvironment.getElementsAnnotatedWith (JavacRoundEnvironment.java:114)
    at org.gwtproject.safehtml.apt.SafeHtmlProcessor.process (SafeHtmlProcessor.java:60)
    at com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor (JavacProcessingEnvironment.java:794)

coz processingEnv.getElementUtils().getTypeElement(OLD_TEMPLATE_ANNOTATION_NAME) return null