### PR TITLE
update SafeHTML dependency to ${revision}

### DIFF
--- a/gwt-safecss-j2cl-tests/pom.xml
+++ b/gwt-safecss-j2cl-tests/pom.xml
@@ -32,13 +32,13 @@
     <dependency>
       <groupId>org.gwtproject.safehtml</groupId>
       <artifactId>gwt-safecss</artifactId>
-      <version>${project.version}</version>
+      <version>${revision}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.gwtproject.safehtml</groupId>
       <artifactId>gwt-safehtml</artifactId>
-      <version>${project.version}</version>
+      <version>${revision}</version>
       <scope>test</scope>
     </dependency>
 

--- a/gwt-safecss/pom.xml
+++ b/gwt-safecss/pom.xml
@@ -53,7 +53,7 @@
     <maven.source.plugin>3.2.1</maven.source.plugin>
 
     <dom.version>HEAD-SNAPSHOT</dom.version>
-    <safehtml.version>HEAD-SNAPSHOT</safehtml.version>
+    <safehtml.version>${revision}</safehtml.version>
   </properties>
 
   <dependencies>

--- a/gwt-safecss/pom.xml
+++ b/gwt-safecss/pom.xml
@@ -53,7 +53,6 @@
     <maven.source.plugin>3.2.1</maven.source.plugin>
 
     <dom.version>HEAD-SNAPSHOT</dom.version>
-    <safehtml.version>${revision}</safehtml.version>
   </properties>
 
   <dependencies>
@@ -65,7 +64,7 @@
     <dependency>
       <groupId>org.gwtproject.safehtml</groupId>
       <artifactId>gwt-safehtml</artifactId>
-      <version>${safehtml.version}</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/gwt-safehtml-processor/pom.xml
+++ b/gwt-safehtml-processor/pom.xml
@@ -53,7 +53,6 @@
     <auto.common.version>0.10</auto.common.version>
     <auto.service.version>1.0-rc7</auto.service.version>
     <compile-testing.version>0.18</compile-testing.version>
-    <gwt.version>2.8.2</gwt.version>
     <javapoet.version>1.12.1</javapoet.version>
     <compile.testing.version>0.18</compile.testing.version>
     <junit.version>4.13</junit.version>
@@ -65,12 +64,12 @@
     <dependency>
       <groupId>org.gwtproject.safehtml</groupId>
       <artifactId>gwt-safecss</artifactId>
-      <version>${project.version}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.gwtproject.safehtml</groupId>
       <artifactId>gwt-safehtml</artifactId>
-      <version>${project.version}</version>
+      <version>${revision}</version>
     </dependency>
 
     <!-- HTML parser used to read template contents -->


### PR DESCRIPTION
gwt-safecss uses a hard coded dependency to gwt-safehtml:HEAD-SNAPSHOT. This is wrong at the time we are building non HEAD-SNAPSHOT versions of the repo.