### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A future-proof port of the `com.google.gwt.safehtml.SafeHtml` and `com.google.gw
 
 ##  Migrating from `com.google.gwt.safehtml.SafeHtml`
 
-See: [SafeHTML-Module](https://github.com/FrankHossfeld/gwt-safehtml/tree/master/gwt-safecss)
+See: [SafeHTML-Module](https://github.com/gwtproject/gwt-safehtml/tree/master/gwt-safehtml)
 
 ##  Migrating from `com.google.gwt.safecss.SafeCss`
 
-See: [SafeCSS-Module](https://github.com/FrankHossfeld/gwt-safehtml/tree/master/gwt-safehtml)
+See: [SafeCSS-Module](https://github.com/gwtproject/gwt-safehtml/tree/master/gwt-safecss)
 
 ## Instructions
 

--- a/gwt-safecss/README.md
+++ b/gwt-safecss/README.md
@@ -25,7 +25,7 @@ A future-proof port of the `org.gwtproject.safehtml.SafeCss` GWT module, with no
 2. Update your GWT module to use
 
    ```xml
-   <inherits name="org.gwtproject.safecss.SafeCSS" />
+   <inherits name="org.gwtproject.safecss.SafeCss" />
    ```
 
 3. Change the `import`s in your Java source files:

--- a/gwt-safehtml/README.md
+++ b/gwt-safehtml/README.md
@@ -1,4 +1,4 @@
-# GWT Safe-HTML & Safe-CSS
+# GWT Safe-HTML
 
 A future-proof port of the `org.gwtproject.safehtml.SafeHtml` GWT module, with no dependency on `gwt-user` (besides the Java Runtime Emulation), to prepare for GWT 3 / J2Cl.
 
@@ -25,7 +25,7 @@ A future-proof port of the `org.gwtproject.safehtml.SafeHtml` GWT module, with n
 2. Update your GWT module to use
 
    ```xml
-   <inherits name="org.gwtproject.safehtml.SafeHTML" />
+   <inherits name="org.gwtproject.safehtml.SafeHtml" />
    ```
 
 3. Change the `import`s in your Java source files:


### PR DESCRIPTION
GWT module instructions say to inherit "org.gwtproject.safehtml.SafeHTML", but in fact it should be "org.gwtproject.safehtml.SafeHtml"